### PR TITLE
move in-place changes to an option and support arbitrary output images

### DIFF
--- a/src/image/extend.js
+++ b/src/image/extend.js
@@ -96,7 +96,7 @@ import minimalBoundingRectangle from './compute/minimalBoundingRectangle';
 export default function extend(Image) {
   let inPlace = { inPlace: true };
 
-  Image.extendMethod('invert', invertFilter, inPlace);
+  Image.extendMethod('invert', invertFilter);
   Image.extendMethod('abs', absFilter, inPlace);
   Image.extendMethod('level', levelFilter, inPlace);
   Image.extendMethod('add', addFilter, inPlace);

--- a/src/image/filter/__tests__/invert.js
+++ b/src/image/filter/__tests__/invert.js
@@ -7,7 +7,7 @@ describe('invert', function () {
     let expected = [25, 172, 135, 255, 155, 115, 242, 240];
 
     const inverted = image.invert();
-    expect(inverted).toBe(image);
+    expect(inverted).not.toBe(image);
     expect(Array.from(inverted.data)).toEqual(expected);
   });
 
@@ -17,7 +17,7 @@ describe('invert', function () {
     let expected = [254, 253, 252, 251];
 
     const inverted = image.invert();
-    expect(inverted).toBe(image);
+    expect(inverted).not.toBe(image);
     expect(Array.from(inverted.data)).toEqual(expected);
   });
 
@@ -27,7 +27,7 @@ describe('invert', function () {
     let expected = [65534, 65533, 65532, 65531];
 
     const inverted = image.invert();
-    expect(inverted).toBe(image);
+    expect(inverted).not.toBe(image);
     expect(Array.from(inverted.data)).toEqual(expected);
   });
 
@@ -38,7 +38,42 @@ describe('invert', function () {
     let expected = Uint8Array.of(170);
 
     const inverted = image.invert();
-    expect(inverted).toBe(image);
+    expect(inverted).not.toBe(image);
     expect(inverted.data).toEqual(expected);
+  });
+
+  it('should allow in-place modification', function () {
+    let image = new Image(1, 2, [230, 83, 120, 255, 100, 140, 13, 240]);
+
+    let expected = [25, 172, 135, 255, 155, 115, 242, 240];
+    const inverted = image.invert({ inPlace: true });
+    expect(Array.from(inverted.data)).toEqual(expected);
+    expect(inverted).toBe(image);
+  });
+
+  it('should allow self out', function () {
+    let image = new Image(1, 2, [230, 83, 120, 255, 100, 140, 13, 240]);
+
+    let expected = [25, 172, 135, 255, 155, 115, 242, 240];
+    const inverted = image.invert({ out: image });
+    expect(Array.from(inverted.data)).toEqual(expected);
+    expect(inverted).toBe(image);
+  });
+
+  it('should allow new out', function () {
+    let image = new Image(1, 2, [230, 83, 120, 255, 100, 140, 13, 240]);
+
+    let expected = [25, 172, 135, 255, 155, 115, 242, 240];
+    const out = new Image(1, 2);
+    const inverted = image.invert({ out });
+    expect(Array.from(inverted.data)).toEqual(expected);
+    expect(inverted).toBe(out);
+  });
+
+  it('should throw for wrong out', function () {
+    let image = new Image(1, 2, [230, 83, 120, 255, 100, 140, 13, 240]);
+
+    const out = new Image(1, 2, { kind: 'GREY' });
+    expect(() => image.invert({ out })).toThrow(/cannot use out\. Its components must be "3" \(found "1"\)/);
   });
 });

--- a/src/image/filter/invert.js
+++ b/src/image/filter/invert.js
@@ -1,32 +1,43 @@
+import { getOutputImageOrInPlace } from '../internal/getOutputImage';
+import copyAlphaChannel from '../internal/copyAlphaChannel';
+
 /**
  * Invert the colors of an image
  * @memberof Image
  * @instance
+ * @param {object} [options]
+ * @param {Image} [options.out]
+ * @param {boolean} [options.inPlace]
  * @return {Image}
  */
-export default function invert() {
+export default function invert(options = {}) {
   this.checkProcessable('invert', {
     bitDepth: [1, 8, 16]
   });
 
+  const out = getOutputImageOrInPlace(this, options);
+
   if (this.bitDepth === 1) {
-    invertBinary(this);
+    invertBinary(this, out);
   } else {
-    invertColor(this);
+    invertColor(this, out);
+    if (this !== out) {
+      copyAlphaChannel(this, out);
+    }
   }
-  return this;
+  return out;
 }
 
-function invertBinary(image) {
+function invertBinary(image, out) {
   for (let i = 0; i < image.data.length; i++) {
-    image.data[i] = ~image.data[i];
+    out.data[i] = ~image.data[i];
   }
 }
 
-function invertColor(image) {
+function invertColor(image, out) {
   for (let pixel = 0; pixel < image.data.length; pixel += image.channels) {
     for (let c = 0; c < image.components; c++) {
-      image.data[pixel + c] = image.maxValue - image.data[pixel + c];
+      out.data[pixel + c] = image.maxValue - image.data[pixel + c];
     }
   }
 }

--- a/src/image/internal/__tests__/getOutputImage.js
+++ b/src/image/internal/__tests__/getOutputImage.js
@@ -75,7 +75,7 @@ test('getOutputImage with requirements NOK - pass this', () => {
 });
 
 test('getOutputImage with requirements NOK - pass other', () => {
-  const other = Image.createFrom(thisImage);  
+  const other = Image.createFrom(thisImage);
   expect(
     () => getOutputImage(thisImage, { out: other }, { width: 4 })
   ).toThrow(/cannot use out\. Its width must be "4" \(found "2"\)/);

--- a/src/image/transform/__tests__/grey.js
+++ b/src/image/transform/__tests__/grey.js
@@ -85,4 +85,21 @@ describe('Grey transform', function () {
       150, 0
     ]);
   });
+
+  it('user-provided output', () => {
+    const image = new Image(2, 1,
+      [
+        100, 150, 200, 255,
+        100, 150, 200, 0
+      ]
+    );
+
+    const out = new Image(2, 1, { kind: 'GREY' });
+    const result = image.grey({ out });
+    expect(result).toBe(out);
+    expect(Array.from(out.data)).toEqual([142, 0]);
+
+    const wrongOut = new Image(2, 1, { kind: 'GREYA' });
+    expect(() => image.grey({ out: wrongOut })).toThrow(/cannot use out\. Its alpha must be "0" \(found "1"\)/);
+  });
 });

--- a/src/image/transform/grey.js
+++ b/src/image/transform/grey.js
@@ -1,5 +1,5 @@
-import Image from '../Image';
 import { GREY } from '../model/model';
+import { getOutputImage } from '../internal/getOutputImage';
 
 import { methods } from './greyAlgorithms';
 
@@ -19,6 +19,7 @@ import { methods } from './greyAlgorithms';
  * @param {boolean} [options.allowGrey=false] - By default only RGB images are allowed.
  *          If true grey images are also allowed and will either return a copy or
  *          apply the alpha channel depending the options
+ * @param {Image} [options.out]
  * @return {Image}
  */
 export default function grey(options = {}) {
@@ -43,7 +44,7 @@ export default function grey(options = {}) {
     mergeAlpha = false;
   }
 
-  let newImage = Image.createFrom(this, {
+  let newImage = getOutputImage(this, options, {
     components: 1,
     alpha: keepAlpha,
     colorModel: GREY


### PR DESCRIPTION
This is a change that I always wanted to make. I applied it to only two methods but the goal is to change all of them to adopt this approach:
- By default all algorithms that modify an image return a new instance
- It is possible to avoid the allocation by providing an `out` option
- For algorithms where it makes sense, there is an `inPlace` option that is equivalent to passing `{ out: thisImage }`

I changed `image.grey()` to show the general change and `image.invert()` to show the inPlace option.

Implementation of `getOutputImage`: https://github.com/image-js/image-js/blob/master/src/image/internal/getOutputImage.js

@lpatiny @stropitek @JeffersonH44 