### PR TITLE
perf: optimize erode and dilate for "only-1" kernels

### DIFF
--- a/benchmark/erode.js
+++ b/benchmark/erode.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { Image } = require('..');
+
+
+function getImage() {
+  const image = new Image(3000, 2000, { kind: 'BINARY' });
+  for (let x = 0; x < image.width; x++) {
+    for (let y = 0; y < image.height; y++) {
+      if (Math.random() > 0.5) {
+        image.setBitXY(x, y);
+      }
+    }
+  }
+  return image;
+}
+
+const kSize = 50;
+const kernel = new Array(kSize).fill(new Array(kSize).fill(1));
+
+let image = getImage();
+image.erode({ kernel });
+
+image = getImage();
+console.time('erode');
+image.erode({ kernel });
+console.timeEnd('erode');

--- a/src/image/morphology/__tests__/erode.js
+++ b/src/image/morphology/__tests__/erode.js
@@ -119,7 +119,7 @@ describe('check the erode function', function () {
     `);
   });
 
-  it('checks fro binary image 5x3 with vertical kernel', function () {
+  it('checks from binary image 5x3 with vertical kernel', function () {
     const kernel = [[1, 1, 1]];
     const mask = new Image(3, 5, binary`
       110

--- a/src/image/morphology/dilate.js
+++ b/src/image/morphology/dilate.js
@@ -42,14 +42,16 @@ export default function dilate(options = {}) {
 
   let result = this;
   for (let i = 0; i < iterations; i++) {
-    const newImage = Image.createFrom(result);
     if (this.bitDepth === 1) {
       if (onlyOnes) {
+        const newImage = result.clone();
         result = dilateOnceBinaryOnlyOnes(result, newImage, kernel.length, kernel[0].length);
       } else {
+        const newImage = Image.createFrom(result);
         result = dilateOnceBinary(result, newImage, kernel);
       }
     } else {
+      const newImage = Image.createFrom(result);
       result = dilateOnce(result, newImage, kernel, channels);
     }
   }
@@ -124,33 +126,23 @@ function dilateOnceBinaryOnlyOnes(img, newImage, kernelWidth, kernelHeight) {
   }
 
   for (let y = 0; y < img.height; y++) {
-    let start = y - radiusY;
     for (let x = 0; x < img.width; x++) {
-      let max = 0;
-      for (let h = 0; h < kernelHeight; h++) {
-        const hh = start + h;
-        if (hh < 0 || hh >= img.height) continue;
-        if (img.getBitXY(x, hh) === 1) {
-          max = 1;
+      maxList[x] = 0;
+      for (let h = Math.max(0, y - radiusY); h < Math.min(img.height, y + radiusY + 1); h++) {
+        if (img.getBitXY(x, h) === 1) {
+          maxList[x] = 1;
           break;
         }
       }
-      maxList[x] = max;
     }
 
     for (let x = 0; x < img.width; x++) {
-      let max = 0;
-      for (let ii = 0; ii < kernelWidth; ii++) {
-        let i = ii - radiusX + x;
-        if (i < 0 || i >= img.width) continue;
+      if (newImage.getBitXY(x, y) === 1) continue;
+      for (let i = Math.max(0, x - radiusX); i < Math.min(img.width, x + radiusX + 1); i++) {
         if (maxList[i] === 1) {
-          max = 1;
+          newImage.setBitXY(x, y);
           break;
         }
-      }
-
-      if (max === 1) {
-        newImage.setBitXY(x, y);
       }
     }
   }

--- a/src/image/morphology/dilate.js
+++ b/src/image/morphology/dilate.js
@@ -24,7 +24,7 @@ export default function dilate(options = {}) {
     bitDepth: [1, 8, 16],
     channel: [1]
   });
-  if ((kernel.columns - 1) % 2 === 1 || (kernel.rows - 1) % 2 === 1) {
+  if (kernel.columns % 2 === 0 || kernel.rows % 2 === 0) {
     throw new TypeError('dilate: The number of rows and columns of the kernel must be odd');
   }
 

--- a/src/image/morphology/dilate.js
+++ b/src/image/morphology/dilate.js
@@ -24,29 +24,43 @@ export default function dilate(options = {}) {
     bitDepth: [1, 8, 16],
     channel: [1]
   });
-  if (kernel.columns - 1 % 2 === 0 || kernel.rows - 1 % 2 === 0) {
+  if ((kernel.columns - 1) % 2 === 1 || (kernel.rows - 1) % 2 === 1) {
     throw new TypeError('dilate: The number of rows and columns of the kernel must be odd');
+  }
+
+  let onlyOnes = true;
+  outer: for (const row of kernel) {
+    for (const value of row) {
+      if (value !== 1) {
+        onlyOnes = false;
+        break outer;
+      }
+    }
   }
 
   channels = validateArrayOfChannels(this, channels, true);
 
   let result = this;
   for (let i = 0; i < iterations; i++) {
+    const newImage = Image.createFrom(result);
     if (this.bitDepth === 1) {
-      result = dilateOnceBinary(result, kernel, channels);
+      if (onlyOnes) {
+        result = dilateOnceBinaryOnlyOnes(result, newImage, kernel.length, kernel[0].length);
+      } else {
+        result = dilateOnceBinary(result, newImage, kernel);
+      }
     } else {
-      result = dilateOnce(result, kernel, channels);
+      result = dilateOnce(result, newImage, kernel, channels);
     }
   }
   return result;
 }
 
-function dilateOnce(img, kernel, channels) {
+function dilateOnce(img, newImage, kernel, channels) {
   const kernelWidth = kernel.length;
   const kernelHeight = kernel[0].length;
   let radiusX = (kernelWidth - 1) / 2;
   let radiusY = (kernelHeight - 1) / 2;
-  let newImage = Image.createFrom(img);
   for (let channel = 0; channel < channels.length; channel++) {
     let c = channels[channel];
     for (let y = 0; y < img.height; y++) {
@@ -71,15 +85,14 @@ function dilateOnce(img, kernel, channels) {
   return newImage;
 }
 
-function dilateOnceBinary(img, kernel) {
+function dilateOnceBinary(img, newImage, kernel) {
   const kernelWidth = kernel.length;
   const kernelHeight = kernel[0].length;
   let radiusX = (kernelWidth - 1) / 2;
   let radiusY = (kernelHeight - 1) / 2;
-  let newImage = Image.createFrom(img);
   for (let y = 0; y < img.height; y++) {
     for (let x = 0; x < img.width; x++) {
-      let min = 0;
+      let max = 0;
       intLoop: for (let jj = 0; jj < kernelHeight; jj++) {
         for (let ii = 0; ii < kernelWidth; ii++) {
           if (kernel[ii][jj] !== 1) continue;
@@ -88,12 +101,12 @@ function dilateOnceBinary(img, kernel) {
           if (j < 0 || i < 0 || i >= img.width || j >= img.height) continue;
           const value = img.getBitXY(i, j);
           if (value === 1) {
-            min = 1;
+            max = 1;
             break intLoop;
           }
         }
       }
-      if (min === 1) {
+      if (max === 1) {
         newImage.setBitXY(x, y);
       }
     }
@@ -101,3 +114,45 @@ function dilateOnceBinary(img, kernel) {
   return newImage;
 }
 
+function dilateOnceBinaryOnlyOnes(img, newImage, kernelWidth, kernelHeight) {
+  const radiusX = (kernelWidth - 1) / 2;
+  const radiusY = (kernelHeight - 1) / 2;
+
+  const maxList = [];
+  for (let x = 0; x < img.width; x++) {
+    maxList.push(1);
+  }
+
+  for (let y = 0; y < img.height; y++) {
+    let start = y - radiusY;
+    for (let x = 0; x < img.width; x++) {
+      let max = 0;
+      for (let h = 0; h < kernelHeight; h++) {
+        const hh = start + h;
+        if (hh < 0 || hh >= img.height) continue;
+        if (img.getBitXY(x, hh) === 1) {
+          max = 1;
+          break;
+        }
+      }
+      maxList[x] = max;
+    }
+
+    for (let x = 0; x < img.width; x++) {
+      let max = 0;
+      for (let ii = 0; ii < kernelWidth; ii++) {
+        let i = ii - radiusX + x;
+        if (i < 0 || i >= img.width) continue;
+        if (maxList[i] === 1) {
+          max = 1;
+          break;
+        }
+      }
+
+      if (max === 1) {
+        newImage.setBitXY(x, y);
+      }
+    }
+  }
+  return newImage;
+}

--- a/src/image/morphology/erode.js
+++ b/src/image/morphology/erode.js
@@ -42,14 +42,16 @@ export default function erode(options = {}) {
 
   let result = this;
   for (let i = 0; i < iterations; i++) {
-    const newImage = Image.createFrom(result);
     if (this.bitDepth === 1) {
       if (onlyOnes) {
+        const newImage = result.clone();
         result = erodeOnceBinaryOnlyOnes(result, newImage, kernel.length, kernel[0].length);
       } else {
+        const newImage = Image.createFrom(result);
         result = erodeOnceBinary(result, newImage, kernel);
       }
     } else {
+      const newImage = Image.createFrom(result);
       result = erodeOnce(result, newImage, kernel, channels);
     }
   }
@@ -124,33 +126,23 @@ function erodeOnceBinaryOnlyOnes(img, newImage, kernelWidth, kernelHeight) {
   }
 
   for (let y = 0; y < img.height; y++) {
-    let start = y - radiusY;
     for (let x = 0; x < img.width; x++) {
-      let min = 1;
-      for (let h = 0; h < kernelHeight; h++) {
-        const hh = start + h;
-        if (hh < 0 || hh >= img.height) continue;
-        if (img.getBitXY(x, hh) === 0) {
-          min = 0;
+      minList[x] = 1;
+      for (let h = Math.max(0, y - radiusY); h < Math.min(img.height, y + radiusY + 1); h++) {
+        if (img.getBitXY(x, h) === 0) {
+          minList[x] = 0;
           break;
         }
       }
-      minList[x] = min;
     }
 
     for (let x = 0; x < img.width; x++) {
-      let min = 1;
-      for (let ii = 0; ii < kernelWidth; ii++) {
-        let i = ii - radiusX + x;
-        if (i < 0 || i >= img.width) continue;
+      if (newImage.getBitXY(x, y) === 0) continue;
+      for (let i = Math.max(0, x - radiusX); i < Math.min(img.width, x + radiusX + 1); i++) {
         if (minList[i] === 0) {
-          min = 0;
+          newImage.clearBitXY(x, y);
           break;
         }
-      }
-
-      if (min === 1) {
-        newImage.setBitXY(x, y);
       }
     }
   }

--- a/src/image/morphology/erode.js
+++ b/src/image/morphology/erode.js
@@ -24,7 +24,7 @@ export default function erode(options = {}) {
     bitDepth: [1, 8, 16],
     channel: [1]
   });
-  if ((kernel.columns - 1) % 2 === 1 || (kernel.rows - 1) % 2 === 1) {
+  if (kernel.columns % 2 === 0 || kernel.rows % 2 === 0) {
     throw new TypeError('erode: The number of rows and columns of the kernel must be odd');
   }
 


### PR DESCRIPTION
With this change, the time required for the current MRZ detection process is reduced by 30%