### PR TITLE
Correct return type of Stack.getAverageImage to Image

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -174,7 +174,7 @@ export declare class Stack extends Array<Image> {
   constructor();
   constructor(images: Image[]);
 
-  getAverageImage(): Stack;
+  getAverageImage(): Image;
   // histogram
   // histograms
   // matchAndCrop


### PR DESCRIPTION
We let this slip through in #525 .