### PR TITLE
feat: restore old implementations of getMask with hull or mbr

### DIFF
--- a/src/image/roi/Roi.js
+++ b/src/image/roi/Roi.js
@@ -638,7 +638,6 @@ export default class Roi {
       });
 
       const mbr = this.mask.minimalBoundingRectangle();
-      console.log(mbr)
       for (let x = 0; x < this.width; x++) {
         for (let y = 0; y < this.height; y++) {
           if (robustPointInPolygon(mbr, [x, y]) !== 1) {

--- a/src/image/roi/__tests__/mbrMask.test.js
+++ b/src/image/roi/__tests__/mbrMask.test.js
@@ -4,7 +4,7 @@ import oneRoi from 'test/oneRoi';
 
 expect.extend({ toBeDeepCloseTo, toMatchCloseTo });
 
-describe('mbrMask', function () {
+describe('mbrContour mask', function () {
   it('roi 4x4 rectangle', function () {
     let roi = oneRoi`
         0110
@@ -13,7 +13,7 @@ describe('mbrMask', function () {
         0110
       `;
 
-    const mask = roi.getMask({ kind: 'mbr' });
+    const mask = roi.getMask({ kind: 'mbrContour' });
 
     let expected = binary`
     111


### PR DESCRIPTION
BREAKING CHANGES:

roi.getMask now returns filled mask for hull and mbr "kind". They previously returned the contour mask. Those have been renamed to "mbrContour" and "hullContour"