### PR TITLE
Chore: Correct typings for exportMethods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,8 +61,9 @@ export declare class Image {
   // exportMethods
   save(path: string, options?: SaveOptions): Promise<void>;
   toDataURL(type?: string, options?: SaveOptions): string;
-  toBase64(type?: string, options?: SaveOptions): string;
-  toBlob(type?: string, quality?: number): Blob;
+  toBase64(type?: string, options?: SaveOptions): string | Promise<string>;
+  toBuffer(options?: SaveOptions): string;
+  toBlob(type?: string, quality?: number): Promise<Blob>;
   getCanvas(): HTMLCanvasElement;
 
   checkProcessable(processName: string, options: object): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ export declare class Image {
   save(path: string, options?: SaveOptions): Promise<void>;
   toDataURL(type?: string, options?: SaveOptions): string;
   toBase64(type?: string, options?: SaveOptions): string | Promise<string>;
-  toBuffer(options?: SaveOptions): string;
+  toBuffer(options?: SaveOptions): Uint8Array;
   toBlob(type?: string, quality?: number): Promise<Blob>;
   getCanvas(): HTMLCanvasElement;
 


### PR DESCRIPTION
- `toBase64` [may also return a Promise](https://image-js.github.io/image-js/#imagetobase64).
- `toBuffer` [is a documented method that was missing](https://image-js.github.io/image-js/#imagetobuffer).
- `toBlob` [returns a Promise](https://image-js.github.io/image-js/#imagetoblob).