### PR TITLE
add TypeScript definition for paintPolygon()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -149,7 +149,11 @@ export declare class Image {
   // paintPoints
   // paintPolyline
   // paintPolylines
-  // paintPolygon
+  paintPolygon(points: Array<Array<number>>, options?: {
+    color?: Array<number>;
+    filled?: boolean;
+  }): Image;
+
   // paintPolygons
 
   // countAlphaPixels


### PR DESCRIPTION
Here is a TypeScript definition for `paintPolygon()` that I needed for a project. I would've added more definitions at one time, however this is a client project and only needs this one at this time. 

Thank you for your library — it's been great to work with! 