### PR TITLE
Add option to ignore color palette in TIFF images

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export declare class Image {
   static createFrom(other: Image, options: ImageConstructorOptions): Image;
   static load(
     image: string | ArrayBuffer | Uint8Array,
-    options?: RequestInit | { ignorePalette: boolean },
+    options?: RequestInit & { ignorePalette: boolean },
   ): Promise<Image>;
 
   getRoiManager(): RoiManager;

--- a/src/image/core/__tests__/loadTIFF.js
+++ b/src/image/core/__tests__/loadTIFF.js
@@ -2,15 +2,19 @@ import { load } from 'test/common';
 
 describe('Load TIFF', () => {
   const tests = [
-    // ['name', components, alpha, bitDepth]
-    ['grey8', 1, 0, 8],
-    ['grey16', 1, 0, 16],
-    ['palette', 3, 0, 16],
-    ['grey32', 1, 0, 32],
+    // ['name', components, alpha, bitDepth, options]
+    ['grey8', 1, 0, 8, undefined],
+    ['grey16', 1, 0, 16, undefined],
+    ['palette', 3, 0, 16, undefined],
+    ['palette', 1, 0, 8, { ignorePalette: true }],
+    ['grey32', 1, 0, 32, undefined],
   ];
 
-  it.each(tests)('%s', async (name, components, alpha, bitDepth) => {
-    const img = await load(`format/tif/${name}.tif`);
+  it.each(tests)('%s', async (name, components, alpha, bitDepth, options) => {
+    const img =
+      options && options.ignorePalette
+        ? await load(`format/tif/${name}.tif`, options)
+        : await load(`format/tif/${name}.tif`);
     expect(img.components).toBe(components);
     expect(img.alpha).toBe(alpha);
     expect(img.bitDepth).toBe(bitDepth);

--- a/src/image/core/load.js
+++ b/src/image/core/load.js
@@ -35,12 +35,12 @@ export default function load(image, options) {
       loadBinary(
         new Uint8Array(image),
         undefined,
-        options ? options.ignorePalette : undefined,
+        options && options.ignorePalette,
       ),
     );
   } else if (image.buffer) {
     return Promise.resolve(
-      loadBinary(image, undefined, options ? options.ignorePalette : undefined),
+      loadBinary(image, undefined, options && options.ignorePalette),
     );
   } else {
     throw new Error('argument to "load" must be a string or buffer.');
@@ -81,7 +81,11 @@ function loadURL(url, options) {
   }
   return binaryDataP.then((binaryData) => {
     const uint8 = new Uint8Array(binaryData);
-    return loadBinary(uint8, dataURL ? url : undefined);
+    return loadBinary(
+      uint8,
+      dataURL ? url : undefined,
+      options && options.ignorePalette,
+    );
   });
 }
 

--- a/test/common.js
+++ b/test/common.js
@@ -12,8 +12,8 @@ export { getImage, getHash };
 
 export { Image, Stack, IJS };
 
-export function load(name) {
-  return Image.load(getImage(name));
+export function load(name, options) {
+  return Image.load(getImage(name), options);
 }
 
 export function getSquare() {


### PR DESCRIPTION
`getImageFromIFD` will automatically create a 16 bit RGB if there if a tiff is of type 3. This makes sense most times, but occasionally, we need the raw single channel greyscale image.