### PR TITLE
allow rotate & crop for bitDepth = 1 images

### DIFF
--- a/src/image/transform/__tests__/crop.js
+++ b/src/image/transform/__tests__/crop.js
@@ -116,3 +116,45 @@ describe('check the crop transform', function () {
     }).toThrow(/size is out of range/);
   });
 });
+
+describe('check the crop transform on binary image', function () {
+  let image;
+  beforeEach(function () {
+    image = new Image(5, 5, [0x03, 0xce, 0xf7, 0x80], { kind: 'BINARY' });
+  });
+
+  it('check the right extract for GREY image', function () {
+    let result = image.crop();
+    expect(getHash(result)).toBe(getHash(image));
+
+    result = image.crop({
+      x: 2,
+      y: 2,
+    });
+    expect(Array.from(result.data)).toStrictEqual([0xff, 0x80]);
+
+    result = image.crop({
+      x: 0,
+      y: 0,
+      height: 2,
+      width: 2,
+    });
+    expect(Array.from(result.data)).toStrictEqual([0x10]);
+
+    result = image.crop({
+      x: 2,
+      y: 2,
+      height: 2,
+      width: 2,
+    });
+    expect(Array.from(result.data)).toStrictEqual([0xf0]);
+
+    result = image.crop({
+      x: 1,
+      y: 3,
+      height: 1,
+      width: 4,
+    });
+    expect(Array.from(result.data)).toStrictEqual([0xf0]);
+  });
+});

--- a/src/image/transform/__tests__/rotate.js
+++ b/src/image/transform/__tests__/rotate.js
@@ -1,4 +1,4 @@
-import { Image } from 'test/common';
+import { Image, getHash } from 'test/common';
 
 describe('check the rotate transform', function () {
   it('90 degrees clockwise grey', function () {
@@ -26,6 +26,53 @@ describe('check the rotate transform', function () {
     expect(Array.from(result.data)).toStrictEqual([6, 5, 4, 3, 2, 1]);
   });
 
+  it('No actual rotation', function () {
+    const image = new Image(3, 2, [1, 2, 3, 4, 5, 6], { kind: 'GREY' });
+
+    const result = image.rotate(360);
+    expect(getHash(result)).toStrictEqual(getHash(image));
+  });
+
+  it('45 degrees binary', function () {
+    const image = new Image(
+      8,
+      8,
+      [0x00, 0x00, 0x3c, 0x3c, 0x3c, 0x3c, 0x00, 0x00],
+      { kind: 'BINARY' },
+    );
+
+    const result = image.rotate(45);
+    expect(Array.from(result.data)).toStrictEqual([
+      241, 252, 31, 17, 199, 17, 241, 62, 115, 159, 39, 241, 255, 127, 255, 128,
+    ]);
+  });
+
+  it('90 degrees binary', function () {
+    const image = new Image(8, 4, [0x00, 0x00, 0xaa, 0x55], { kind: 'BINARY' });
+
+    const result = image.rotate(90);
+    expect(Array.from(result.data)).toStrictEqual([0x48, 0x48, 0x48, 0x48]);
+  });
+
+  it('180 degrees binary', function () {
+    const image = new Image(8, 4, [0x00, 0x00, 0xaa, 0x55], { kind: 'BINARY' });
+
+    const result = image.rotate(180);
+    expect(Array.from(result.data)).toStrictEqual([0xaa, 0x55, 0x00, 0x00]);
+  });
+
+  it('270 degrees binary', function () {
+    const image = new Image(
+      8,
+      8,
+      [0x00, 0x00, 0x3c, 0x3c, 0x3c, 0x3c, 0x00, 0x00],
+      { kind: 'BINARY' },
+    );
+
+    const result = image.rotate(270);
+    expect(getHash(result)).toStrictEqual(getHash(image));
+  });
+
   it('negative angle grey', function () {
     const image = new Image(3, 2, [1, 2, 3, 4, 5, 6], { kind: 'GREY' });
     const rotate90 = image.rotate(90);
@@ -33,5 +80,12 @@ describe('check the rotate transform', function () {
     expect(Array.from(rotate90.data)).toStrictEqual(
       Array.from(rotateMin270.data),
     );
+  });
+
+  it('invalid argument types', function () {
+    expect(function () {
+      const image = new Image(3, 2, [1, 2, 3, 4, 5, 6], { kind: 'GREY' });
+      image.rotate('45°');
+    }).toThrow(/angle must be a number/);
   });
 });

--- a/src/image/transform/__tests__/rotateFree.js
+++ b/src/image/transform/__tests__/rotateFree.js
@@ -1,5 +1,7 @@
 import { Image } from 'test/common';
 
+import rotateFree from '../rotateFree';
+
 describe('check the rotate transform with free rotation', function () {
   it('GREY image', function () {
     let image = new Image(
@@ -19,5 +21,65 @@ describe('check the rotate transform with free rotation', function () {
       1, 1, 0, 255, 0, 1, 1, 2, 1, 1, 0, 255, 1, 2, 4, 2, 1, 255, 255, 255, 3,
       4, 3, 255, 255, 255, 255, 255, 3, 255, 255, 255,
     ]);
+  });
+
+  it('GREY image bilinear', function () {
+    let image = new Image(
+      5,
+      5,
+      [
+        0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 2, 2, 2, 0, 1, 2, 4, 3, 0, 1, 2, 3,
+        3,
+      ],
+      { kind: 'GREY' },
+    );
+
+    let result = image.rotate(45, { interpolation: 'bilinear' });
+
+    expect(Array.from(result.data)).toStrictEqual([
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 255, 255, 255, 255,
+      255, 0, 1, 0, 255, 255, 255, 0, 1, 2, 1, 0, 255, 0, 0, 2, 3, 2, 1, 0, 255,
+      0, 0, 3, 2, 0, 255, 255, 255, 0, 0, 0, 255, 255,
+    ]);
+  });
+
+  it('45 degrees binary bilinear', function () {
+    const image = new Image(
+      8,
+      8,
+      [0x00, 0x00, 0x3c, 0x3c, 0x3c, 0x3c, 0x00, 0x00],
+      { kind: 'BINARY' },
+    );
+
+    const result = image.rotate(45, { interpolation: 'bilinear' });
+    expect(Array.from(result.data)).toStrictEqual([
+      251, 254, 63, 131, 226, 56, 226, 62, 35, 142, 35, 224, 254, 63, 239, 128,
+    ]);
+  });
+
+  it('30 degrees binary', function () {
+    const image = new Image(
+      8,
+      8,
+      [0xff, 0xff, 0xc3, 0xdb, 0xdb, 0xc3, 0xff, 0xff],
+      { kind: 'BINARY' },
+    );
+
+    const result = image.rotate(30);
+    expect(Array.from(result.data)).toStrictEqual([
+      255, 255, 255, 127, 207, 236, 243, 127, 63, 239, 255, 255, 240,
+    ]);
+  });
+
+  it('invalid argument types', function () {
+    expect(function () {
+      const image = new Image(
+        8,
+        8,
+        [0xff, 0xff, 0xc3, 0xdb, 0xdb, 0xc3, 0xff, 0xff],
+        { kind: 'BINARY' },
+      );
+      rotateFree.call(image, '45°');
+    }).toThrow(/degrees must be a number/);
   });
 });

--- a/src/image/transform/crop.js
+++ b/src/image/transform/crop.js
@@ -21,55 +21,100 @@ export default function crop(options = {}) {
     x = 0,
     y = 0,
     width = this.width - x,
-    height = this.height - y,
+    height = this.height - y
   } = options;
-
-  this.checkProcessable('max', {
-    bitDepth: [8, 16],
+  this.checkProcessable('crop', {
+    bitDepth: [1, 8, 16]
   });
-
   x = Math.round(x);
   y = Math.round(y);
   width = Math.round(width);
   height = Math.round(height);
 
   if (x > this.width - 1 || y > this.height - 1) {
-    throw new RangeError(
-      `crop: origin (x:${x}, y:${y}) out of range (${this.width - 1}; ${
-        this.height - 1
-      })`,
-    );
+    throw new RangeError(`crop: origin (x:${x}, y:${y}) out of range (${this.width - 1}; ${this.height - 1})`);
   }
+
   if (width <= 0 || height <= 0) {
-    throw new RangeError(
-      `crop: width and height (width:${width}; height:${height}) must be positive numbers`,
-    );
+    throw new RangeError(`crop: width and height (width:${width}; height:${height}) must be positive numbers`);
   }
+
   if (x < 0 || y < 0) {
-    throw new RangeError(
-      `crop: x and y (x:${x}, y:${y}) must be positive numbers`,
-    );
+    throw new RangeError(`crop: x and y (x:${x}, y:${y}) must be positive numbers`);
   }
+
   if (width > this.width - x || height > this.height - y) {
-    throw new RangeError(
-      `crop: (x: ${x}, y:${y}, width:${width}, height:${height}) size is out of range`,
-    );
+    throw new RangeError(`crop: (x: ${x}, y:${y}, width:${width}, height:${height}) size is out of range`);
   }
 
-  let newImage = Image.createFrom(this, { width, height, position: [x, y] });
+  let result = this;
+  if(this.bitDepth === 1) {
+    const newImage = new Image(width, height, {
+      kind: 'BINARY',
+      parent: this
+    });
+    result = cropBinary(
+        this,
+        newImage,
+        x,
+        y,
+        width,
+        height
+      );
+  } else {
+    const newImage = Image.createFrom(this, {
+      width,
+      height,
+      position: [x, y]
+    });
+    result = cropDefault(
+        this,
+        newImage,
+        x,
+        y,
+        width,
+        height
+      );
+  }
 
-  let xWidth = width * this.channels;
+  return result
+}
+
+function cropDefault(img, newImage, x, y, width, height) {
+  let xWidth = width * img.channels;
   let y1 = y + height;
-
   let ptr = 0; // pointer for new array
 
-  let jLeft = x * this.channels;
+  let jLeft = x * img.channels;
 
   for (let i = y; i < y1; i++) {
-    let j = i * this.width * this.channels + jLeft;
+    let j = i * img.width * img.channels + jLeft;
     let jL = j + xWidth;
+
     for (; j < jL; j++) {
-      newImage.data[ptr++] = this.data[j];
+        newImage.data[ptr++] = img.data[j];
+    }
+  }
+
+  return newImage;
+}
+
+function cropBinary(img, newImage, x, y, width, height) {
+  let xWidth = width * img.channels;
+  let y1 = y + height;
+  let ptr = 0; // pointer for new array
+
+  let jLeft = x * img.channels;
+
+  for (let i = y; i < y1; i++) {
+    let j = i * img.width * img.channels + jLeft;
+    let jL = j + xWidth;
+
+    for (; j < jL; j++) {
+      if(img.getBit(j)) {
+        newImage.setBit(ptr);
+      }
+      ++ptr;
     }
   }
 

--- a/src/image/transform/crop.js
+++ b/src/image/transform/crop.js
@@ -21,10 +21,10 @@ export default function crop(options = {}) {
     x = 0,
     y = 0,
     width = this.width - x,
-    height = this.height - y
+    height = this.height - y,
   } = options;
   this.checkProcessable('crop', {
-    bitDepth: [1, 8, 16]
+    bitDepth: [1, 8, 16],
   });
   x = Math.round(x);
   y = Math.round(y);
@@ -32,52 +32,48 @@ export default function crop(options = {}) {
   height = Math.round(height);
 
   if (x > this.width - 1 || y > this.height - 1) {
-    throw new RangeError(`crop: origin (x:${x}, y:${y}) out of range (${this.width - 1}; ${this.height - 1})`);
+    throw new RangeError(
+      `crop: origin (x:${x}, y:${y}) out of range (${this.width - 1}; ${
+        this.height - 1
+      })`,
+    );
   }
 
   if (width <= 0 || height <= 0) {
-    throw new RangeError(`crop: width and height (width:${width}; height:${height}) must be positive numbers`);
+    throw new RangeError(
+      `crop: width and height (width:${width}; height:${height}) must be positive numbers`,
+    );
   }
 
   if (x < 0 || y < 0) {
-    throw new RangeError(`crop: x and y (x:${x}, y:${y}) must be positive numbers`);
+    throw new RangeError(
+      `crop: x and y (x:${x}, y:${y}) must be positive numbers`,
+    );
   }
 
   if (width > this.width - x || height > this.height - y) {
-    throw new RangeError(`crop: (x: ${x}, y:${y}, width:${width}, height:${height}) size is out of range`);
+    throw new RangeError(
+      `crop: (x: ${x}, y:${y}, width:${width}, height:${height}) size is out of range`,
+    );
   }
 
   let result = this;
-  if(this.bitDepth === 1) {
+  if (this.bitDepth === 1) {
     const newImage = new Image(width, height, {
       kind: 'BINARY',
-      parent: this
+      parent: this,
     });
-    result = cropBinary(
-        this,
-        newImage,
-        x,
-        y,
-        width,
-        height
-      );
+    result = cropBinary(this, newImage, x, y, width, height);
   } else {
     const newImage = Image.createFrom(this, {
       width,
       height,
-      position: [x, y]
+      position: [x, y],
     });
-    result = cropDefault(
-        this,
-        newImage,
-        x,
-        y,
-        width,
-        height
-      );
+    result = cropDefault(this, newImage, x, y, width, height);
   }
 
-  return result
+  return result;
 }
 
 function cropDefault(img, newImage, x, y, width, height) {
@@ -92,7 +88,7 @@ function cropDefault(img, newImage, x, y, width, height) {
     let jL = j + xWidth;
 
     for (; j < jL; j++) {
-        newImage.data[ptr++] = img.data[j];
+      newImage.data[ptr++] = img.data[j];
     }
   }
 
@@ -111,7 +107,7 @@ function cropBinary(img, newImage, x, y, width, height) {
     let jL = j + xWidth;
 
     for (; j < jL; j++) {
-      if(img.getBit(j)) {
+      if (img.getBit(j)) {
         newImage.setBit(ptr);
       }
       ++ptr;

--- a/src/image/transform/rotate.js
+++ b/src/image/transform/rotate.js
@@ -12,6 +12,9 @@ import rotateFree from './rotateFree';
  * @return {Image} The new rotated image
  */
 export function rotate(angle, options) {
+  this.checkProcessable('rotate', {
+    bitDepth: [1, 8, 16]
+  });
   if (typeof angle !== 'number') {
     throw new TypeError('angle must be a number');
   }
@@ -23,39 +26,65 @@ export function rotate(angle, options) {
   switch (angle % 360) {
     case 0:
       return this.clone();
+
     case 90:
       return rotateRight.call(this);
+
     case 180:
       return rotate180.call(this);
+
     case 270:
       return rotateLeft.call(this);
+
     default:
       return rotateFree.call(this, angle, options);
   }
 }
-
 /**
  * Rotates an image counter-clockwise
  * @memberof Image
  * @instance
  * @return {Image} The new rotated image
  */
+
+
 export function rotateLeft() {
-  const newImage = Image.createFrom(this, {
-    width: this.height,
-    height: this.width,
-  });
-  const newMaxHeight = newImage.height - 1;
-  for (let i = 0; i < this.height; i++) {
-    for (let j = 0; j < this.width; j++) {
-      for (let k = 0; k < this.channels; k++) {
-        newImage.setValueXY(i, newMaxHeight - j, k, this.getValueXY(j, i, k));
+  if(this.bitDepth === 1) {
+    const newImage = new Image(this.height, this.width, {
+      kind: 'BINARY',
+      parent: this
+    });
+
+    const newMaxHeight = newImage.height - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        if(this.getBitXY(j, i)) {
+          newImage.setBitXY(i, newMaxHeight - j);
+        }
       }
     }
-  }
-  return newImage;
-}
 
+    return newImage;
+  } else {
+    const newImage = Image.createFrom(this, {
+      width: this.height,
+      height: this.width
+    });
+
+    const newMaxHeight = newImage.height - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        for (let k = 0; k < this.channels; k++) {
+          newImage.setValueXY(i, newMaxHeight - j, k, this.getValueXY(j, i, k));
+        }
+      }
+    }
+
+    return newImage;
+  }
+}
 /**
  * Rotates an image clockwise
  * @memberof Image
@@ -63,37 +92,78 @@ export function rotateLeft() {
  * @return {Image} The new rotated image
  */
 
+
 export function rotateRight() {
-  const newImage = Image.createFrom(this, {
-    width: this.height,
-    height: this.width,
-  });
-  const newMaxWidth = newImage.width - 1;
-  for (let i = 0; i < this.height; i++) {
-    for (let j = 0; j < this.width; j++) {
-      for (let k = 0; k < this.channels; k++) {
-        newImage.setValueXY(newMaxWidth - i, j, k, this.getValueXY(j, i, k));
+  if(this.bitDepth === 1) {
+    const newImage = new Image(this.height, this.width, {
+      kind: 'BINARY',
+      parent: this
+    });
+
+    const newMaxWidth = newImage.width - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        if(this.getBitXY(j, i)) {
+          newImage.setBitXY(newMaxWidth - i, j);
+        }
       }
     }
+
+    return newImage;
+  } else {
+    const newImage = Image.createFrom(this, {
+      width: this.height,
+      height: this.width
+    });
+
+    const newMaxWidth = newImage.width - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        for (let k = 0; k < this.channels; k++) {
+          newImage.setValueXY(newMaxWidth - i, j, k, this.getValueXY(j, i, k));
+        }
+      }
+    }
+
+    return newImage;
   }
-  return newImage;
 }
 
 function rotate180() {
-  const newImage = Image.createFrom(this);
-  const newMaxWidth = newImage.width - 1;
-  const newMaxHeight = newImage.height - 1;
-  for (let i = 0; i < this.height; i++) {
-    for (let j = 0; j < this.width; j++) {
-      for (let k = 0; k < this.channels; k++) {
-        newImage.setValueXY(
-          newMaxWidth - j,
-          newMaxHeight - i,
-          k,
-          this.getValueXY(j, i, k),
-        );
+  if(this.bitDepth === 1) {
+    const newImage = new Image(this.width, this.height, {
+      kind: 'BINARY',
+      parent: this
+    });
+
+    const newMaxWidth = newImage.width - 1;
+    const newMaxHeight = newImage.height - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        if(this.getBitXY(j, i)) {
+          newImage.setBitXY(newMaxWidth - j, newMaxHeight - i);
+        }
       }
     }
+
+    return newImage;
+  } else {
+    const newImage = Image.createFrom(this);
+
+    const newMaxWidth = newImage.width - 1;
+    const newMaxHeight = newImage.height - 1;
+
+    for (let i = 0; i < this.height; i++) {
+      for (let j = 0; j < this.width; j++) {
+        for (let k = 0; k < this.channels; k++) {
+          newImage.setValueXY(newMaxWidth - j, newMaxHeight - i, k, this.getValueXY(j, i, k));
+        }
+      }
+    }
+
+    return newImage;
   }
-  return newImage;
 }

--- a/src/image/transform/rotate.js
+++ b/src/image/transform/rotate.js
@@ -13,7 +13,7 @@ import rotateFree from './rotateFree';
  */
 export function rotate(angle, options) {
   this.checkProcessable('rotate', {
-    bitDepth: [1, 8, 16]
+    bitDepth: [1, 8, 16],
   });
   if (typeof angle !== 'number') {
     throw new TypeError('angle must be a number');
@@ -47,19 +47,18 @@ export function rotate(angle, options) {
  * @return {Image} The new rotated image
  */
 
-
 export function rotateLeft() {
-  if(this.bitDepth === 1) {
+  if (this.bitDepth === 1) {
     const newImage = new Image(this.height, this.width, {
       kind: 'BINARY',
-      parent: this
+      parent: this,
     });
 
     const newMaxHeight = newImage.height - 1;
 
     for (let i = 0; i < this.height; i++) {
       for (let j = 0; j < this.width; j++) {
-        if(this.getBitXY(j, i)) {
+        if (this.getBitXY(j, i)) {
           newImage.setBitXY(i, newMaxHeight - j);
         }
       }
@@ -69,7 +68,7 @@ export function rotateLeft() {
   } else {
     const newImage = Image.createFrom(this, {
       width: this.height,
-      height: this.width
+      height: this.width,
     });
 
     const newMaxHeight = newImage.height - 1;
@@ -92,19 +91,18 @@ export function rotateLeft() {
  * @return {Image} The new rotated image
  */
 
-
 export function rotateRight() {
-  if(this.bitDepth === 1) {
+  if (this.bitDepth === 1) {
     const newImage = new Image(this.height, this.width, {
       kind: 'BINARY',
-      parent: this
+      parent: this,
     });
 
     const newMaxWidth = newImage.width - 1;
 
     for (let i = 0; i < this.height; i++) {
       for (let j = 0; j < this.width; j++) {
-        if(this.getBitXY(j, i)) {
+        if (this.getBitXY(j, i)) {
           newImage.setBitXY(newMaxWidth - i, j);
         }
       }
@@ -114,7 +112,7 @@ export function rotateRight() {
   } else {
     const newImage = Image.createFrom(this, {
       width: this.height,
-      height: this.width
+      height: this.width,
     });
 
     const newMaxWidth = newImage.width - 1;
@@ -132,10 +130,10 @@ export function rotateRight() {
 }
 
 function rotate180() {
-  if(this.bitDepth === 1) {
+  if (this.bitDepth === 1) {
     const newImage = new Image(this.width, this.height, {
       kind: 'BINARY',
-      parent: this
+      parent: this,
     });
 
     const newMaxWidth = newImage.width - 1;
@@ -143,7 +141,7 @@ function rotate180() {
 
     for (let i = 0; i < this.height; i++) {
       for (let j = 0; j < this.width; j++) {
-        if(this.getBitXY(j, i)) {
+        if (this.getBitXY(j, i)) {
           newImage.setBitXY(newMaxWidth - j, newMaxHeight - i);
         }
       }
@@ -159,7 +157,12 @@ function rotate180() {
     for (let i = 0; i < this.height; i++) {
       for (let j = 0; j < this.width; j++) {
         for (let k = 0; k < this.channels; k++) {
-          newImage.setValueXY(newMaxWidth - j, newMaxHeight - i, k, this.getValueXY(j, i, k));
+          newImage.setValueXY(
+            newMaxWidth - j,
+            newMaxHeight - i,
+            k,
+            this.getValueXY(j, i, k),
+          );
         }
       }
     }

--- a/src/image/transform/rotateFree.js
+++ b/src/image/transform/rotateFree.js
@@ -5,7 +5,7 @@ export default function rotateFree(degrees, options = {}) {
   const {
     interpolation = validInterpolations.nearestneighbor,
     width = this.width,
-    height = this.height
+    height = this.height,
   } = options;
 
   if (typeof degrees !== 'number') {
@@ -13,9 +13,13 @@ export default function rotateFree(degrees, options = {}) {
   }
 
   const interpolationToUse = (0, checkInterpolation)(interpolation);
-  const radians = degrees * Math.PI / 180;
-  const newWidth = Math.floor(Math.abs(width * Math.cos(radians)) + Math.abs(height * Math.sin(radians)));
-  const newHeight = Math.floor(Math.abs(height * Math.cos(radians)) + Math.abs(width * Math.sin(radians)));
+  const radians = (degrees * Math.PI) / 180;
+  const newWidth = Math.floor(
+    Math.abs(width * Math.cos(radians)) + Math.abs(height * Math.sin(radians)),
+  );
+  const newHeight = Math.floor(
+    Math.abs(height * Math.cos(radians)) + Math.abs(width * Math.sin(radians)),
+  );
 
   const cos = Math.cos(-radians);
   const sin = Math.sin(-radians);
@@ -43,42 +47,91 @@ export default function rotateFree(degrees, options = {}) {
   const incrementX = Math.floor(width / 2 - x0);
   const incrementY = Math.floor(height / 2 - y0);
 
-  if(this.bitDepth === 1) {
+  if (this.bitDepth === 1) {
     const newImage = new Image(newWidth, newHeight, {
       kind: 'BINARY',
-      parent: this
+      parent: this,
     });
 
     switch (interpolationToUse) {
       case validInterpolations.nearestneighbor:
-        return rotateBinaryNearestNeighbor(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+        return rotateBinaryNearestNeighbor(
+          this,
+          newImage,
+          incrementX,
+          incrementY,
+          x0,
+          y0,
+          cos,
+          sin,
+        );
 
       case validInterpolations.bilinear:
-        return rotateBinaryBilinear(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+        return rotateBinaryBilinear(
+          this,
+          newImage,
+          incrementX,
+          incrementY,
+          x0,
+          y0,
+          cos,
+          sin,
+        );
 
       default:
-        throw new Error(`unsupported rotate interpolation: ${interpolationToUse}`);
+        throw new Error(
+          `unsupported rotate interpolation: ${interpolationToUse}`,
+        );
     }
   } else {
     const newImage = Image.createFrom(this, {
       width: newWidth,
-      height: newHeight
+      height: newHeight,
     });
 
     switch (interpolationToUse) {
       case validInterpolations.nearestneighbor:
-        return rotateNearestNeighbor(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+        return rotateNearestNeighbor(
+          this,
+          newImage,
+          incrementX,
+          incrementY,
+          x0,
+          y0,
+          cos,
+          sin,
+        );
 
       case validInterpolations.bilinear:
-        return rotateBilinear(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+        return rotateBilinear(
+          this,
+          newImage,
+          incrementX,
+          incrementY,
+          x0,
+          y0,
+          cos,
+          sin,
+        );
 
       default:
-        throw new Error(`unsupported rotate interpolation: ${interpolationToUse}`);
+        throw new Error(
+          `unsupported rotate interpolation: ${interpolationToUse}`,
+        );
     }
   }
 }
 
-function rotateNearestNeighbor(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+function rotateNearestNeighbor(
+  thisImage,
+  newImage,
+  incrementX,
+  incrementY,
+  x0,
+  y0,
+  cos,
+  sin,
+) {
   for (let i = 0; i < newImage.width; i += 1) {
     for (let j = 0; j < newImage.height; j += 1) {
       for (let c = 0; c < thisImage.channels; c++) {
@@ -101,13 +154,28 @@ function rotateNearestNeighbor(thisImage, newImage, incrementX, incrementY, x0, 
   return newImage;
 }
 
-function rotateBinaryNearestNeighbor(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+function rotateBinaryNearestNeighbor(
+  thisImage,
+  newImage,
+  incrementX,
+  incrementY,
+  x0,
+  y0,
+  cos,
+  sin,
+) {
   for (let i = 0; i < newImage.width; i += 1) {
     for (let j = 0; j < newImage.height; j += 1) {
       let x = Math.round((i - x0) * cos - (j - y0) * sin + x0) + incrementX;
       let y = Math.round((j - y0) * cos + (i - x0) * sin + y0) + incrementY;
 
-      if (x < 0 || x >= thisImage.width || y < 0 || y >= thisImage.height || thisImage.getBitXY(x, y)) {
+      if (
+        x < 0 ||
+        x >= thisImage.width ||
+        y < 0 ||
+        y >= thisImage.height ||
+        thisImage.getBitXY(x, y)
+      ) {
         newImage.setBitXY(i, j);
       }
     }
@@ -116,7 +184,16 @@ function rotateBinaryNearestNeighbor(thisImage, newImage, incrementX, incrementY
   return newImage;
 }
 
-function rotateBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+function rotateBilinear(
+  thisImage,
+  newImage,
+  incrementX,
+  incrementY,
+  x0,
+  y0,
+  cos,
+  sin,
+) {
   let stride = thisImage.width * thisImage.channels;
 
   for (let j = 0; j < newImage.height; j++) {
@@ -141,7 +218,12 @@ function rotateBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos
           let B = thisImage.data[index + thisImage.channels];
           let C = thisImage.data[index + stride];
           let D = thisImage.data[index + stride + thisImage.channels];
-          let result = A + xDiff * (B - A) + yDiff * (C - A) + xDiff * yDiff * (A - B - C + D) | 0;
+          let result =
+            (A +
+              xDiff * (B - A) +
+              yDiff * (C - A) +
+              xDiff * yDiff * (A - B - C + D)) |
+            0;
           newImage.setValueXY(i, j, c, result);
         }
       }
@@ -151,7 +233,16 @@ function rotateBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos
   return newImage;
 }
 
-function rotateBinaryBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+function rotateBinaryBilinear(
+  thisImage,
+  newImage,
+  incrementX,
+  incrementY,
+  x0,
+  y0,
+  cos,
+  sin,
+) {
   let stride = thisImage.width;
 
   for (let j = 0; j < newImage.height; j++) {
@@ -171,8 +262,12 @@ function rotateBinaryBilinear(thisImage, newImage, incrementX, incrementY, x0, y
         let B = thisImage.getBit(index + 1);
         let C = thisImage.getBit(index + stride);
         let D = thisImage.getBit(index + 1 + stride);
-        let result = A | (xDiff & (B - A)) | (yDiff & (C - A)) | (xDiff & yDiff & (A - B - C + D));
-        if(result > 0) newImage.setBitXY(i, j);
+        let result =
+          A |
+          (xDiff & (B - A)) |
+          (yDiff & (C - A)) |
+          (xDiff & yDiff & (A - B - C + D));
+        if (result > 0) newImage.setBitXY(i, j);
       }
     }
   }

--- a/src/image/transform/rotateFree.js
+++ b/src/image/transform/rotateFree.js
@@ -5,32 +5,26 @@ export default function rotateFree(degrees, options = {}) {
   const {
     interpolation = validInterpolations.nearestneighbor,
     width = this.width,
-    height = this.height,
+    height = this.height
   } = options;
 
   if (typeof degrees !== 'number') {
     throw new TypeError('degrees must be a number');
   }
-  const interpolationToUse = checkInterpolation(interpolation);
 
-  const radians = (degrees * Math.PI) / 180;
-  const newWidth = Math.floor(
-    Math.abs(width * Math.cos(radians)) + Math.abs(height * Math.sin(radians)),
-  );
-  const newHeight = Math.floor(
-    Math.abs(height * Math.cos(radians)) + Math.abs(width * Math.sin(radians)),
-  );
-  const newImage = Image.createFrom(this, {
-    width: newWidth,
-    height: newHeight,
-  });
+  const interpolationToUse = (0, checkInterpolation)(interpolation);
+  const radians = degrees * Math.PI / 180;
+  const newWidth = Math.floor(Math.abs(width * Math.cos(radians)) + Math.abs(height * Math.sin(radians)));
+  const newHeight = Math.floor(Math.abs(height * Math.cos(radians)) + Math.abs(width * Math.sin(radians)));
+
   const cos = Math.cos(-radians);
   const sin = Math.sin(-radians);
-
   let x0 = newWidth / 2;
   let y0 = newHeight / 2;
+
   if (newWidth % 2 === 0) {
     x0 = x0 - 0.5;
+
     if (newHeight % 2 === 0) {
       y0 = y0 - 0.5;
     } else {
@@ -38,6 +32,7 @@ export default function rotateFree(degrees, options = {}) {
     }
   } else {
     x0 = Math.floor(x0);
+
     if (newHeight % 2 === 0) {
       y0 = y0 - 0.5;
     } else {
@@ -48,46 +43,42 @@ export default function rotateFree(degrees, options = {}) {
   const incrementX = Math.floor(width / 2 - x0);
   const incrementY = Math.floor(height / 2 - y0);
 
-  switch (interpolationToUse) {
-    case validInterpolations.nearestneighbor:
-      return rotateNearestNeighbor(
-        this,
-        newImage,
-        incrementX,
-        incrementY,
-        x0,
-        y0,
-        cos,
-        sin,
-      );
-    case validInterpolations.bilinear:
-      return rotateBilinear(
-        this,
-        newImage,
-        incrementX,
-        incrementY,
-        x0,
-        y0,
-        cos,
-        sin,
-      );
-    default:
-      throw new Error(
-        `unsupported rotate interpolation: ${interpolationToUse}`,
-      );
+  if(this.bitDepth === 1) {
+    const newImage = new Image(newWidth, newHeight, {
+      kind: 'BINARY',
+      parent: this
+    });
+
+    switch (interpolationToUse) {
+      case validInterpolations.nearestneighbor:
+        return rotateBinaryNearestNeighbor(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+
+      case validInterpolations.bilinear:
+        return rotateBinaryBilinear(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+
+      default:
+        throw new Error(`unsupported rotate interpolation: ${interpolationToUse}`);
+    }
+  } else {
+    const newImage = Image.createFrom(this, {
+      width: newWidth,
+      height: newHeight
+    });
+
+    switch (interpolationToUse) {
+      case validInterpolations.nearestneighbor:
+        return rotateNearestNeighbor(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+
+      case validInterpolations.bilinear:
+        return rotateBilinear(this, newImage, incrementX, incrementY, x0, y0, cos, sin);
+
+      default:
+        throw new Error(`unsupported rotate interpolation: ${interpolationToUse}`);
+    }
   }
 }
 
-function rotateNearestNeighbor(
-  thisImage,
-  newImage,
-  incrementX,
-  incrementY,
-  x0,
-  y0,
-  cos,
-  sin,
-) {
+function rotateNearestNeighbor(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
   for (let i = 0; i < newImage.width; i += 1) {
     for (let j = 0; j < newImage.height; j += 1) {
       for (let c = 0; c < thisImage.channels; c++) {
@@ -106,20 +97,28 @@ function rotateNearestNeighbor(
       }
     }
   }
+
   return newImage;
 }
 
-function rotateBilinear(
-  thisImage,
-  newImage,
-  incrementX,
-  incrementY,
-  x0,
-  y0,
-  cos,
-  sin,
-) {
+function rotateBinaryNearestNeighbor(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+  for (let i = 0; i < newImage.width; i += 1) {
+    for (let j = 0; j < newImage.height; j += 1) {
+      let x = Math.round((i - x0) * cos - (j - y0) * sin + x0) + incrementX;
+      let y = Math.round((j - y0) * cos + (i - x0) * sin + y0) + incrementY;
+
+      if (x < 0 || x >= thisImage.width || y < 0 || y >= thisImage.height || thisImage.getBitXY(x, y)) {
+        newImage.setBitXY(i, j);
+      }
+    }
+  }
+
+  return newImage;
+}
+
+function rotateBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
   let stride = thisImage.width * thisImage.channels;
+
   for (let j = 0; j < newImage.height; j++) {
     for (let i = 0; i < newImage.width; i++) {
       let x = (i - x0) * cos - (j - y0) * sin + x0 + incrementX;
@@ -128,6 +127,7 @@ function rotateBilinear(
       let y1 = y | 0;
       let xDiff = x - x1;
       let yDiff = y - y1;
+
       for (let c = 0; c < thisImage.channels; c++) {
         if (x < 0 || x >= thisImage.width || y < 0 || y >= thisImage.height) {
           if (thisImage.alpha === 1 && c === thisImage.channels - 1) {
@@ -137,23 +137,45 @@ function rotateBilinear(
           }
         } else {
           let index = (y1 * thisImage.width + x1) * thisImage.channels + c;
-
           let A = thisImage.data[index];
           let B = thisImage.data[index + thisImage.channels];
           let C = thisImage.data[index + stride];
           let D = thisImage.data[index + stride + thisImage.channels];
-
-          let result =
-            (A +
-              xDiff * (B - A) +
-              yDiff * (C - A) +
-              xDiff * yDiff * (A - B - C + D)) |
-            0;
-
+          let result = A + xDiff * (B - A) + yDiff * (C - A) + xDiff * yDiff * (A - B - C + D) | 0;
           newImage.setValueXY(i, j, c, result);
         }
       }
     }
   }
+
+  return newImage;
+}
+
+function rotateBinaryBilinear(thisImage, newImage, incrementX, incrementY, x0, y0, cos, sin) {
+  let stride = thisImage.width;
+
+  for (let j = 0; j < newImage.height; j++) {
+    for (let i = 0; i < newImage.width; i++) {
+      let x = (i - x0) * cos - (j - y0) * sin + x0 + incrementX;
+      let y = (j - y0) * cos + (i - x0) * sin + y0 + incrementY;
+      let x1 = x | 0;
+      let y1 = y | 0;
+      let xDiff = x - x1;
+      let yDiff = y - y1;
+
+      if (x < 0 || x >= thisImage.width || y < 0 || y >= thisImage.height) {
+        newImage.setBitXY(i, j);
+      } else {
+        let index = y1 * thisImage.width + x1;
+        let A = thisImage.getBit(index);
+        let B = thisImage.getBit(index + 1);
+        let C = thisImage.getBit(index + stride);
+        let D = thisImage.getBit(index + 1 + stride);
+        let result = A | (xDiff & (B - A)) | (yDiff & (C - A)) | (xDiff & yDiff & (A - B - C + D));
+        if(result > 0) newImage.setBitXY(i, j);
+      }
+    }
+  }
+
   return newImage;
 }


### PR DESCRIPTION
rotation of binary images did not fail but instead yielded weird output images.

Also includes:
- add rotate processable check
- fix crop processable check (announced process was 'max' on fail)