### PR TITLE
Bump fast-bmp to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@swiftcarrot/color-fns": "^3.2.0",
     "blob-util": "^2.0.2",
     "canny-edge-detector": "^1.0.0",
-    "fast-bmp": "^1.0.0",
+    "fast-bmp": "^2.0.1",
     "fast-jpeg": "^1.0.1",
     "fast-list": "^1.0.3",
     "fast-png": "^6.1.0",


### PR DESCRIPTION
Follow-up to https://github.com/image-js/fast-bmp/issues/9