### PR TITLE
fix(Image): use instance check on isImage

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -16,8 +16,6 @@ import extend from './extend';
 import getImageParameters from './internal/getImageParameters';
 import RoiManager from './roi/manager';
 
-const objectToString = Object.prototype.toString;
-
 /**
  * Class representing an image.
  * This class allows to manipulate easily images directly in the browser or in node.
@@ -337,7 +335,7 @@ export default class Image {
   }
 
   static isImage(object) {
-    return object instanceof Image || objectToString.call(object) === '[object IJSImage]';
+    return object instanceof Image;
   }
 
   /**

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -337,7 +337,7 @@ export default class Image {
   }
 
   static isImage(object) {
-    return objectToString.call(object) === '[object IJSImage]';
+    return object instanceof Image || objectToString.call(object) === '[object IJSImage]';
   }
 
   /**


### PR DESCRIPTION
This PR updates static `Image.isImage` method to initially verify the object via instance check.

Not sure if the verification should be done via `toString` though, because of the following issue:

```js
// here we have a class named Demo
class Demo {
    // We return "Demo" here
    get [Symbol.toStringTag]() {
        return "Demo";
    }
    // this is implemented in same way as Image
    static isDemo(obj) {
        return Object.prototype.toString.call(obj) === "[object Demo]";
    }
}

// here we have another class named Demo2
class Demo2 {
    // Here we are returning the same "Demo" string
    get [Symbol.toStringTag]() {
        return "Demo";
    }
    // this too is equivalent to Image's isImage method
    static isDemo(obj) {
        return Object.prototype.toString.call(obj) === "[object Demo]";
    }
}

// instantiating each of these classes
const demo1 = new Demo();
const demo2 = new Demo2();

// since we are just verifying via toString return value, we don't know if demo1 and demo2 are actually equal
console.log(`${demo1.toString()} ${demo2.toString()}`) // Demo Demo
console.log(`${Demo.isDemo(demo2)} ${Demo.isDemo(demo1)}`) // true true
```

Due to this, `Image.isImage` may not always validate the actual Image which can cause problems. Let me know if `toString` implementation should not be removed.