### PR TITLE
fix: setMatrix() return this object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,7 @@ export declare class Image {
   getRow(row: number, channel?: number): Array<number>;
   getColumn(row: number, channel?: number): Array<number>;
   getMatrix(options?: { channel?: number }): Matrix;
-  setMatrix(matrix: Matrix, options?: { channel?: number });
+  setMatrix(matrix: Matrix, options?: { channel?: number }): this;
   getPixelsArray(): Array<Array<number>>;
   getIntersection(mask2: Image): object;
   getClosestCommonParent(mask: Image): Image;

--- a/src/image/utility/setMatrix.js
+++ b/src/image/utility/setMatrix.js
@@ -7,6 +7,8 @@ import { Matrix } from 'ml-matrix';
  * @param {Matrix} matrix
  * @param {object} [options]
  * @param {number} [options.channel]
+ *
+ * @return {this}
  */
 export default function setMatrix(matrix, options = {}) {
   matrix = new Matrix(matrix);
@@ -35,4 +37,6 @@ export default function setMatrix(matrix, options = {}) {
       this.setValueXY(y, x, channel, matrix.get(x, y));
     }
   }
+
+  return this;
 }


### PR DESCRIPTION
Typing fix for `setMatrix()` function (Issue [#607](https://github.com/image-js/image-js/issues/607))

- In `src/image/utility/setMatrix.js`, the function `setMatrix()` return the `this` object (similar to the `setChannel()` function). 
- In `src/image/utility/setMatrix.js`, add the return type to the setMatrix() function documentation
- Adjust the type definition in` index.d.ts`