### PR TITLE
feat: add typing and jsdoc for cannyEdge

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,7 +196,11 @@ export declare class Image {
     options?: { border?: Array<number> },
   ): Array<number>;
 
-  // cannyEdge
+  cannyEdge(options?: {
+    gaussianBlur: number;
+    lowThreshold: number;
+    highThreshold: number;
+  }): Image;
   convolution(kernel: Kernel, options?: ConvolutionOptions): Image;
   extract(
     mask: Image,

--- a/index.d.ts
+++ b/index.d.ts
@@ -197,9 +197,9 @@ export declare class Image {
   ): Array<number>;
 
   cannyEdge(options?: {
-    gaussianBlur: number;
-    lowThreshold: number;
-    highThreshold: number;
+    gaussianBlur?: number;
+    lowThreshold?: number;
+    highThreshold?: number;
   }): Image;
   convolution(kernel: Kernel, options?: ConvolutionOptions): Image;
   extract(

--- a/src/image/operator/cannyEdge.js
+++ b/src/image/operator/cannyEdge.js
@@ -4,9 +4,9 @@ import cannyEdgeDetector from 'canny-edge-detector';
  * @memberof Image
  * @instance
  * @param {object} [options]
- * @param {number} [options.gaussianBlur] - Sigma parameter for the gaussian filter step (default: 1.1)
- * @param {number} [options.lowThreshold] - Low threshold for the hysteresis procedure (default: 10)
- * @param {number} [options.highThreshold] - High threshold for the hysteresis procedure (default: 30)
+ * @param {number} [options.gaussianBlur=1.1] - Sigma parameter for the gaussian filter step
+ * @param {number} [options.lowThreshold=10] - Low threshold for the hysteresis procedure
+ * @param {number} [options.highThreshold=30] - High threshold for the hysteresis procedure
  * @return {Image}
  */
 export default function cannyEdge(options) {

--- a/src/image/operator/cannyEdge.js
+++ b/src/image/operator/cannyEdge.js
@@ -4,6 +4,9 @@ import cannyEdgeDetector from 'canny-edge-detector';
  * @memberof Image
  * @instance
  * @param {object} [options]
+ * @param {number} [options.gaussianBlur] - Sigma parameter for the gaussian filter step (default: 1.1)
+ * @param {number} [options.lowThreshold] - Low threshold for the hysteresis procedure (default: 10)
+ * @param {number} [options.highThreshold] - High threshold for the hysteresis procedure (default: 30)
  * @return {Image}
  */
 export default function cannyEdge(options) {


### PR DESCRIPTION
Adding typing for cannyEdge method 

- Add a type definition in `index.d.ts` for cannyEdge method
- In `src/image/operator/cannyEdge.js`, add options description to function documentation