### PR TITLE
fix: type for options.size in Image.pad function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -143,7 +143,7 @@ export declare class Image {
   grey(options?: GreyOptions): Image;
   mask(options?: MaskOptions): Image;
   pad(options?: {
-    size?: number;
+    size?: number | [number, number];
     algorithm?: 'set' | 'copy';
     color?: Array<number>;
   }): Image;

--- a/src/image/transform/pad.js
+++ b/src/image/transform/pad.js
@@ -7,7 +7,7 @@ import copy from '../internal/copy';
  * @memberof Image
  * @instance
  * @param {object} [options]
- * @param {number} [options.size=0]
+ * @param {number | [number, number]} [options.size=0]
  * @param {string} [options.algorithm='copy']
  * @param {array<number>} [options.color]
  * @return {Image}


### PR DESCRIPTION
I looked at the code and found that `size` actually supports inputting both width and height simultaneously. However, the current `index.d.ts` only allows one value to be input. This causes an type error tip when used in TypeScript, so I had to add `as any`.