### PR TITLE
fix: add resolution to BMP format

### DIFF
--- a/src/load/__tests__/decodeBmp.test.ts
+++ b/src/load/__tests__/decodeBmp.test.ts
@@ -28,6 +28,32 @@ test('should decode grey image', () => {
   ]);
 });
 
+test('should decode image resolution', () => {
+  const rgba = decodeBmp(testUtils.loadBuffer('formats/bmp/2x2RGBA.bmp'));
+
+  expect(rgba.originalResolution).toStrictEqual({
+    x: 2835,
+    y: 2835,
+    unit: 'meter',
+  });
+  expect(rgba.normalizedResolution).toStrictEqual({
+    x: 28.35,
+    y: 28.35,
+  });
+
+  const grey = decodeBmp(testUtils.loadBuffer('formats/bmp/gray5x5.bmp'));
+
+  expect(grey.originalResolution).toStrictEqual({
+    x: 11811,
+    y: 11811,
+    unit: 'meter',
+  });
+  expect(grey.normalizedResolution).toStrictEqual({
+    x: 118.11,
+    y: 118.11,
+  });
+});
+
 test('decode 5x5 mask', () => {
   const mask = testUtils.createGreyImage([
     [0, 0, 0, 0, 0],

--- a/src/load/decodeBmp.ts
+++ b/src/load/decodeBmp.ts
@@ -4,6 +4,10 @@ import { Image } from '../Image.ts';
 import { Mask } from '../Mask.ts';
 import type { ImageColorModel } from '../utils/constants/colorModels.ts';
 
+import type { Resolution } from './load.types.ts';
+
+type DecodedBmp = ReturnType<typeof decode>;
+
 /**
  * Decode a BMP. See the fast-bmp npm module.
  * @param data - The data to decode.
@@ -32,6 +36,24 @@ export function decodeBmp(data: Uint8Array): Image {
     return new Image(decodedData.width, decodedData.height, {
       colorModel,
       data: decodedData.data as Uint8Array,
+      resolution: getBmpResolution(decodedData),
     });
   }
+}
+
+/**
+ * Gets image's resolution from its parsed data. BMP stores resolution in
+ * pixels per meter.
+ * @param bmp - Parsed BMP image.
+ * @returns Object with resolution data if it is defined.
+ */
+function getBmpResolution(bmp: DecodedBmp): Resolution | undefined {
+  if (!bmp.xPixelsPerMeter || !bmp.yPixelsPerMeter) {
+    return undefined;
+  }
+  return {
+    x: bmp.xPixelsPerMeter,
+    y: bmp.yPixelsPerMeter,
+    unit: 'meter',
+  };
 }


### PR DESCRIPTION
#810 added resolution metadata to the PNG decoder, and the TIFF decoder already populates it from `xResolution`/`yResolution`. The BMP decoder doesn't, even though `fast-bmp` exposes `xPixelsPerMeter`/`yPixelsPerMeter` from the DIB header, so `decodeBmp` was dropping resolution that is present in the file.

BMP stores resolution in pixels per meter, which maps to the `meter` unit (the same case as PNG). I added a `getBmpResolution` helper mirroring `getResolution`/`getTiffResolution` and pass it on the standard image path. When the header has no resolution (pixels per meter is 0) it returns `undefined`, like the other decoders.

The existing `2x2RGBA.bmp` and `gray5x5.bmp` fixtures already carry resolution (2835 and 11811 px/m), so I added a test on `originalResolution`/`normalizedResolution`. Before the change `originalResolution` is `undefined`; after it returns `{ x: 2835, y: 2835, unit: 'meter' }` (28.35 px/cm) and `{ x: 11811, y: 11811, unit: 'meter' }` (118.11 px/cm).

The 1-bit BMP path returns a `Mask`, which has no resolution field, so it is left unchanged. This matches the PNG 1-bit path.
